### PR TITLE
fix(chromium headless): fix chromium headless fail on Cannot start Chrome headless

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,4 +8,5 @@ RUN sed -i -e 's/v3\.8/edge/g' /etc/apk/repositories
 RUN apk add --no-cache \
   chromium \
   udev \
-  ttf-freefont
+  ttf-freefont \
+  libc6-compat


### PR DESCRIPTION
Latest build is faling on our CI with message:

```
Cannot start ChromeHeadless
```

After some experiments, is seems latest chromium build needs libc6-compat to make this works.